### PR TITLE
Add filp/whoops dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
             "role": "Developer"
     }],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "filp/whoops": "1.*"
     },
     "require-dev": {
     	"slim/slim": "2.*",


### PR DESCRIPTION
As per [this doc](https://github.com/filp/whoops/blob/master/docs/Framework%20Integration.md#contributing-an-integration-with-a-framework), a depency on `filp/whoops` is required for an offical bridge.

I've recommended your package for slim. [see here](https://github.com/filp/whoops/issues/243).
