### PR TITLE
removed unused parameter in errorHandler factory

### DIFF
--- a/src/Zeuxisoo/Whoops/Provider/Slim/WhoopsMiddleware.php
+++ b/src/Zeuxisoo/Whoops/Provider/Slim/WhoopsMiddleware.php
@@ -50,11 +50,10 @@ class WhoopsMiddleware {
             $whoops->pushHandler($jsonResponseHandler);
             $whoops->register();
 
-            $container['errorHandler'] = function($c) use ($whoops) {
+            $container['errorHandler'] = function() use ($whoops) {
                 return new WhoopsErrorHandler($whoops);
             };
 
-            //
             $container['whoops'] = $whoops;
         }
 


### PR DESCRIPTION
I removed the unused parameter in the erorrhandler factory.

My custom di container tries to automatically link the parameters , since there is no type hinting i cannot automatically bind it. I wanted to type hint it to (Interop\Container\ContainerInterface) But the param $c is not used at all.

