### PR TITLE
Better DI and preserve request object

### DIFF
--- a/src/Zeuxisoo/Whoops/Provider/Slim/WhoopsMiddleware.php
+++ b/src/Zeuxisoo/Whoops/Provider/Slim/WhoopsMiddleware.php
@@ -8,12 +8,15 @@ use Zeuxisoo\Whoops\Provider\Slim\WhoopsErrorHandler;
 
 class WhoopsMiddleware {
 
+    public function __construct( $container ){
+        $this->container = $container;
+    }
+
     public function __invoke($request, $response, $next) {
         $app         = $next;
-        $container   = $app->getContainer();
+        $container   = $this->container;
         $settings    = $container['settings'];
         $environment = $container['environment'];
-        $request     = $container['request'];
 
         if (isset($settings['debug']) === true && $settings['debug'] === true) {
             // Enable PrettyPageHandler with editor options


### PR DESCRIPTION
Slim injects the dependency container every time a middleware is created from a class. This commit uses that instead of assuming that the `$next` callable is going to be an instance of `\Slim\App`.

Also, looks like there's no need to get the request object from the dependency container since the middleware is already receiving it as a parameter, otherwise any changes made to the PSR-7 request object are lost.

The above causes an issue for example when using `Slim-Csrf`because the request would no longer have "attributes" set by this middleware.

Hope it helps.

Regards!
