### PR TITLE
Use ContainerInterface and support different kind of containers

### DIFF
--- a/src/Zeuxisoo/Whoops/Provider/Slim/WhoopsGuard.php
+++ b/src/Zeuxisoo/Whoops/Provider/Slim/WhoopsGuard.php
@@ -25,11 +25,15 @@ class WhoopsGuard {
     public function setHandlers(array $handlers) {
         $this->handlers = $handlers;
     }
-
+    
+    public function setContainerSetImplementation($containerSetImplementation) {
+        $this->containerSetImplementation=$containerSetImplementation;
+    }
+    
     public function install() {
         $container   = $this->app->getContainer();
-        $settings    = $container['settings'];
-        $environment = $container['environment'];
+        $settings    = $container->get('settings');
+        $environment = $container->get('environment');
 
         if (isset($settings['debug']) === true && $settings['debug'] === true) {
             // Enable PrettyPageHandler with editor options

--- a/tests/WhoopsGuardTest.php
+++ b/tests/WhoopsGuardTest.php
@@ -31,7 +31,7 @@ class WhoopsGuardTest extends PHPUnit_Framework_TestCase {
 
         $whoopsGuard = new WhoopsGuard();
         $whoopsGuard->setApp($app);
-        $whoopsGuard->setRequest($container['request']);
+        $whoopsGuard->setRequest($container->get('request'));
         $whoopsGuard->setHandlers([]);
         $whoopsGuard->install();
 
@@ -67,7 +67,7 @@ class WhoopsGuardTest extends PHPUnit_Framework_TestCase {
 
         $whoopsGuard = new WhoopsGuard();
         $whoopsGuard->setApp($app);
-        $whoopsGuard->setRequest($container['request']);
+        $whoopsGuard->setRequest($container->get('request'));
         $whoopsGuard->setHandlers([]);
         $whoopsGuard->install();
 
@@ -110,11 +110,11 @@ class WhoopsGuardTest extends PHPUnit_Framework_TestCase {
 
         $whoopsGuard = new WhoopsGuard();
         $whoopsGuard->setApp($app);
-        $whoopsGuard->setRequest($container['request']);
+        $whoopsGuard->setRequest($container->get('request'));
         $whoopsGuard->setHandlers([]);
         $whoopsGuard->install();
 
-        $handlers = $container['whoops']->getHandlers();
+        $handlers = $container->get('whoops')->getHandlers();
 
         unset($_SERVER['HTTP_X_REQUESTED_WITH']);
 
@@ -132,7 +132,7 @@ class WhoopsGuardTest extends PHPUnit_Framework_TestCase {
 
         $whoopsGuard = new WhoopsGuard();
         $whoopsGuard->setApp($app);
-        $whoopsGuard->setRequest($container['request']);
+        $whoopsGuard->setRequest($container->get('request'));
         $whoopsGuard->setHandlers([function($exception, $inspector, $run) {
             $message = $exception->getMessage();
             $title   = $inspector->getExceptionName();
@@ -142,7 +142,7 @@ class WhoopsGuardTest extends PHPUnit_Framework_TestCase {
         }]);
         $whoopsGuard->install();
 
-        $handlers = $container['whoops']->getHandlers();
+        $handlers = $container->get('whoops')->getHandlers();
 
         $this->assertInstanceOf(WhoopsCallbackHandler::class, $handlers[1]);
     }
@@ -158,12 +158,12 @@ class WhoopsGuardTest extends PHPUnit_Framework_TestCase {
 
         $whoopsGuard = new WhoopsGuard();
         $whoopsGuard->setApp($app);
-        $whoopsGuard->setRequest($container['request']);
+        $whoopsGuard->setRequest($container->get('request'));
         $whoopsGuard->setHandlers([]);
         $whoopsGuard->install();
 
-        $this->assertInstanceOf(WhoopsErrorHandler::class, $container['phpErrorHandler']);
-        $this->assertInstanceOf(WhoopsErrorHandler::class, $container['errorHandler']);
+        $this->assertInstanceOf(WhoopsErrorHandler::class, $container->get('phpErrorHandler'));
+        $this->assertInstanceOf(WhoopsErrorHandler::class, $container->get('errorHandler'));
     }
 
 }

--- a/tests/WhoopsGuardTest.php
+++ b/tests/WhoopsGuardTest.php
@@ -165,5 +165,49 @@ class WhoopsGuardTest extends PHPUnit_Framework_TestCase {
         $this->assertInstanceOf(WhoopsErrorHandler::class, $container->get('phpErrorHandler'));
         $this->assertInstanceOf(WhoopsErrorHandler::class, $container->get('errorHandler'));
     }
+    
+    public function testErrorHandlerInStandardContainerWithoutArrayAccessIsReplaced() {
+        $container = new ContainerWithoutArrayAccess([
+            'settings' => [
+                'debug' => true,
+            ]
+        ]);
+        
+        $app = new App($container);
+
+        $whoopsGuard = new WhoopsGuard();
+        $whoopsGuard->setApp($app);
+        $whoopsGuard->setRequest($container->get('request'));
+        $whoopsGuard->setHandlers([]);
+        $whoopsGuard->install();
+
+        $this->assertInstanceOf(WhoopsRun::class, $container->get('whoops'));
+        $this->assertInstanceOf(WhoopsErrorHandler::class, $container->get('phpErrorHandler'));
+        $this->assertInstanceOf(WhoopsErrorHandler::class, $container->get('errorHandler'));
+    }
+    
+    public function testErrorHandlerInStrangeContainerWithoutArrayAccessIsReplaced() {
+        $container = new StrangeContainerWithoutArrayAccess([
+            'settings' => [
+                'debug' => true,
+            ]
+        ]);
+        
+        $app = new App($container);
+
+        $whoopsGuard = new WhoopsGuard();
+        $whoopsGuard->setApp($app);
+        $whoopsGuard->setRequest($container->get('request'));
+        $whoopsGuard->setHandlers([]);
+        
+        $whoopsGuard->setContainerSetImplementation(function($container,$id,$value){$container->strangeSetter($value, $id);});
+        
+        $whoopsGuard->install();
+
+        
+        $this->assertInstanceOf(WhoopsRun::class, $container->get('whoops'));
+        $this->assertInstanceOf(WhoopsErrorHandler::class, $container->get('phpErrorHandler'));
+        $this->assertInstanceOf(WhoopsErrorHandler::class, $container->get('errorHandler'));
+    }
 
 }

--- a/tests/WhoopsMiddlewareDICompatibilityTest.php
+++ b/tests/WhoopsMiddlewareDICompatibilityTest.php
@@ -99,7 +99,7 @@ class WhoopsMiddlewareDICompatibilityTest extends PHPUnit_Framework_TestCase {
         $response = $app->run();
 
         // Get added whoops handlers
-        $handlers = $container['whoops']->getHandlers();
+        $handlers = $container->get('whoops')->getHandlers();
 
         // Only 1 will got because the JSON handler will not added if it is not ajax request
         $this->assertEquals(1, count($handlers));

--- a/tests/WhoopsMiddlewareTest.php
+++ b/tests/WhoopsMiddlewareTest.php
@@ -99,7 +99,7 @@ class WhoopsMiddlewareTest extends PHPUnit_Framework_TestCase {
         $response = $app->run();
 
         // Get added whoops handlers
-        $handlers = $container['whoops']->getHandlers();
+        $handlers = $container->get('whoops')->getHandlers();
 
         // Only 1 will got because the JSON handler will not added if it is not ajax request
         $this->assertEquals(1, count($handlers));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,3 +8,45 @@ class Stackable {
         return $res->write('Center');
     }
 }
+
+class ContainerWithoutArrayAccess implements \Psr\Container\ContainerInterface{
+    
+    protected $container;
+    
+    function __construct(array $values=[]) {
+        $this->container = new Slim\Container($values);
+    }
+    
+    public function get($id) {
+        return $this->container->get($id);
+    }
+
+    public function has($id) {
+        return $this->container->has($id);
+    }
+    
+    public function set($id,$value) {
+        $this->container[$id]=$value;
+    }
+}
+
+class StrangeContainerWithoutArrayAccess implements \Psr\Container\ContainerInterface{
+    
+    protected $container;
+    
+    function __construct(array $values=[]) {
+        $this->container = new Slim\Container($values);
+    }
+    
+    public function get($id) {
+        return $this->container->get($id);
+    }
+
+    public function has($id) {
+        return $this->container->has($id);
+    }
+    
+    public function strangeSetter($value,$id) {
+        $this->container[$id]=$value;
+    }
+}


### PR DESCRIPTION
Hi, I noticed that your code uses `ArrayAccess` to get and set dependencies from the container. Slim allows for any `ContainerInterface` and  I wanted to use [PHP-ID](http://php-di.org/doc/frameworks/slim.html) which [does not implement `ArrayAccess` any more](http://php-di.org/change-log.html#30). Instead it uses [`set()`](http://php-di.org/doc/container.html#set).

The `ContainerInterface` only defines `get(<id>)` and `has(<id>)` so I changed all occurrences of getting dependencies from the container from `$container[<id>]` to `$container->get(<id>)`

For setting `phpErrorHandler`, `errorHandler`, `whoops` I added a check:
If the container implements `ArrayAccess` it is used to set the dependencies, if not a callback is executed. I figured that 

```php
$container->set(<id>,<value>);
```
should be enough for most of the simple containers out there.

If you need a custom callback you can set it with `setContainerSetImplementation(<callback>)`.
