### PR TITLE
Allow Customising Page Titles

### DIFF
--- a/src/Zeuxisoo/Whoops/Provider/Slim/WhoopsGuard.php
+++ b/src/Zeuxisoo/Whoops/Provider/Slim/WhoopsGuard.php
@@ -50,6 +50,10 @@ class WhoopsGuard {
                 $prettyPageHandler->setEditor($settings['whoops.editor']);
             }
 
+            if (empty($settings['whoops.pageTitle']) === false) {
+                $prettyPageHandler->setPageTitle($settings['whoops.pageTitle']);
+            }
+
             // Add more information to the PrettyPageHandler
             $prettyPageHandler->addDataTable('Slim Application', [
                 'Application Class' => get_class($this->app),

--- a/tests/WhoopsMiddlewareDICompatibilityTest.php
+++ b/tests/WhoopsMiddlewareDICompatibilityTest.php
@@ -78,6 +78,7 @@ class WhoopsMiddlewareDICompatibilityTest extends PHPUnit_Framework_TestCase {
             'settings' => [
                 'debug' => true,
                 'whoops.editor' => 'sublime',
+                'whoops.pageTitle' => 'Custom Page Title',
             ]
         ]);
         $container = $app->getContainer();
@@ -104,6 +105,7 @@ class WhoopsMiddlewareDICompatibilityTest extends PHPUnit_Framework_TestCase {
         // Only 1 will got because the JSON handler will not added if it is not ajax request
         $this->assertEquals(1, count($handlers));
         $this->assertEquals('subl://open?url=file://test_path&line=169', $handlers[0]->getEditorHref('test_path', 169));
+        $this->assertEquals('Custom Page Title', $handlers[0]->getPageTitle());
     }
 
 }

--- a/tests/WhoopsMiddlewareTest.php
+++ b/tests/WhoopsMiddlewareTest.php
@@ -78,6 +78,7 @@ class WhoopsMiddlewareTest extends PHPUnit_Framework_TestCase {
             'settings' => [
                 'debug' => true,
                 'whoops.editor' => 'sublime',
+                'whoops.pageTitle' => 'Custom Page Title',
             ]
         ]);
         $container = $app->getContainer();
@@ -104,6 +105,7 @@ class WhoopsMiddlewareTest extends PHPUnit_Framework_TestCase {
         // Only 1 will got because the JSON handler will not added if it is not ajax request
         $this->assertEquals(1, count($handlers));
         $this->assertEquals('subl://open?url=file://test_path&line=169', $handlers[0]->getEditorHref('test_path', 169));
+        $this->assertEquals('Custom Page Title', $handlers[0]->getPageTitle());
     }
 
 }


### PR DESCRIPTION
Allows setting a custom page title for the HTML error page with `whoops.pageTitle` in the settings array (alongside `whoops.editor`)