### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_script:
     - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls:dev-master -n ; fi
 
 script:
-    - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then mkdir -p build/logs && phpunit --coverage-clover build/logs/clover.xml ; fi
-    - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then phpunit ; fi
+    - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then mkdir -p build/logs && php vendor/bin/phpunit --coverage-clover build/logs/clover.xml ; fi
+    - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then php vendor/bin/phpunit ; fi
 
 after_script:
     - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then php vendor/bin/coveralls -v ; fi


### PR DESCRIPTION
[It looks like](https://travis-ci.org/zeuxisoo/php-slim-whoops/jobs/316246848) Travis is referencing a global version of PHPUnit (v6.5.2), rather than the local version installed via Composer (4.8.36). The new version seems to require >= PHP 7.0, breaking on HHVM. Hopefully these changes fix that.