### PR TITLE
Update to Whoops 2.2.x for PHP 7.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
     - hhvm
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,20 @@ php:
     - 7.0
     - 7.1
     - 7.2
-    - hhvm
+
+branches:
+    only:
+        - master
 
 before_script:
-    - composer self-update
-    - composer install --no-interaction --prefer-source
-    - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls:dev-master -n ; fi
+    - travis_retry composer self-update
+    - travis_retry composer install --no-interaction --prefer-source
+    - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls:1.* squizlabs/php_codesniffer:2.* -n ; fi
+    - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then composer install -n ; fi
 
 script:
-    - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then mkdir -p build/logs && phpunit --coverage-clover build/logs/clover.xml ; fi
-    - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then phpunit ; fi
+    - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then mkdir -p build/logs && php vendor/bin/phpunit --coverage-clover build/logs/clover.xml ; fi
+    - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then php vendor/bin/phpunit ; fi
 
 after_script:
-    - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then php vendor/bin/coveralls -v ; fi
+    - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then php vendor/bin/coveralls --coverage_clover=build/logs/clover.xml -v ; fi

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }],
     "require": {
         "php": ">=5.5.0",
-        "filp/whoops": "2.1.*"
+        "filp/whoops": "2.2.*"
     },
     "require-dev": {
     	"slim/slim": "3.8.*",


### PR DESCRIPTION
In the [Changelog ](https://github.com/filp/whoops/blob/master/CHANGELOG.md) aren't any API-changes mentioned. I guess it is safe to update