### PR TITLE
Added in a resolver setting, if resolver and editor is found in settings

### DIFF
--- a/src/Zeuxisoo/Whoops/Slim/WhoopsGuard.php
+++ b/src/Zeuxisoo/Whoops/Slim/WhoopsGuard.php
@@ -25,6 +25,7 @@ class WhoopsGuard {
         $this->settings = array_merge([
             'enable' => true,
             'editor' => '',
+            'resolver' => '',
             'title'  => '',
         ], $settings);
     }
@@ -64,6 +65,9 @@ class WhoopsGuard {
 
         if (empty($this->settings['editor']) === false) {
             $prettyPageHandler->setEditor($this->settings['editor']);
+        }
+        if (empty($this->settings['resolver']) === false && empty($this->settings['editor']) === false) {
+             $prettyPageHandler->addEditor($this->settings['editor'],$this->settings['resolver']);
         }
 
         if (empty($this->settings['title']) === false) {

--- a/tests/WhoopsGuardTest.php
+++ b/tests/WhoopsGuardTest.php
@@ -71,6 +71,21 @@ class WhoopsGuardTest extends TestCase {
             'subl://open?url=file://%2Ffoo%2Fbar.php&line=10'
         );
     }
+    public function testSetEditorResolver() {
+        $request = (new ServerRequestFactory)->createServerRequest("GET", "http://example.com/");
+
+        $guard = new WhoopsGuard([ 'editor' => 'phpstorm', 'resolver' => 'file://%file:%line' ]);
+        $guard->setRequest($request);
+
+        $whoops = $guard->install();
+
+        $prettyPageHandler = $whoops->getHandlers()[0];
+
+        $this->assertEquals(
+            $prettyPageHandler->getEditorHref('/foo/bar.php', 10),
+            'file://%2Ffoo%2Fbar.php:10'
+        );
+    }
 
     public function testPageTitle() {
         $request = (new ServerRequestFactory)->createServerRequest("GET", "http://example.com/");


### PR DESCRIPTION
Added in a resolver setting, if resolver and editor is found in settings then use addEditor() instead of setEditor()

issue here: https://github.com/zeuxisoo/php-slim-whoops/issues/30

basically on windows we need to use a remote call. 

usage on this would be something like

```
        $app->add(new WhoopsMiddleware(array(
            'enable' => true,
            'editor' => 'phpstorm',
            'resolver' => 'http://localhost:8091?message=%file:%line'
        )));
```
if resolver isnt set then it defaults to setEditor() 


