### PR TITLE
Drop Support for PHP 7.3 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,10 +11,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.4, 8.0]
+                php: [7.4, 8.0, 8.1]
                 experimental: [false]
                 include:
-                    - php: 8.0
+                    - php: 8.1
                       analysis: true
 
         steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['7.3', '7.4', '8.0']
+                php: [7.4, 8.0]
                 experimental: [false]
                 include:
                     - php: 8.0
                       analysis: true
-                    - php: 8.1
-                      experimental: true
 
         steps:
             - name: Checkout Code

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
 /report
-
+/.idea
+/.vscode
 composer.phar

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Slim whoops
 
-PHP whoops error on slim framework
+PHP Whoops error handler for [Slim Framework](https://www.slimframework.com).
 
 ## Status
 
@@ -54,7 +54,7 @@ Or you can pass more settings to the `WhoopsMiddleware`
 
 ## Custom Editor String
 
-If your editor do not included in [default editor list][2], you can custom it like
+If your editor is not included in [default editor list][2], you can customize it like
 
     $app->add(new Zeuxisoo\Whoops\Slim\WhoopsMiddleware([
         'editor' => function($file, $line) {
@@ -86,7 +86,7 @@ Version `0.3.0` or above version
 
 Version `0.2.0`
 
-- You must to install the `whoops` library manually.
+- You must install the `whoops` library manually.
 
 
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
             "role": "Developer"
     }],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "filp/whoops": "^2.14"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "slim/http": "1.2.*",
         "slim/twig-view": "3.2.*",
         "equip/dispatch": "^2.0",
-        "phpunit/phpunit": "^8.5 || ^9.5"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "510946946acd580fef9487b166d1c617",
+    "content-hash": "1d6d5f616385be04a3ea50f97fc951a7",
     "packages": [
         {
             "name": "filp/whoops",
-            "version": "2.14.4",
+            "version": "2.14.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "f056f1fe935d9ed86e698905a957334029899895"
+                "reference": "a63e5e8f26ebbebf8ed3c5c691637325512eb0dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/f056f1fe935d9ed86e698905a957334029899895",
-                "reference": "f056f1fe935d9ed86e698905a957334029899895",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/a63e5e8f26ebbebf8ed3c5c691637325512eb0dc",
+                "reference": "a63e5e8f26ebbebf8ed3c5c691637325512eb0dc",
                 "shasum": ""
             },
             "require": {
@@ -67,7 +67,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.14.4"
+                "source": "https://github.com/filp/whoops/tree/2.14.5"
             },
             "funding": [
                 {
@@ -75,34 +75,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-03T12:00:00+00:00"
+            "time": "2022-01-07T12:00:00+00:00"
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.0"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "src"
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -123,9 +123,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         }
     ],
     "packages-dev": [
@@ -410,16 +410,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.0",
+            "version": "v4.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "50953a2691a922aa1769461637869a0a2faa3f53"
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/50953a2691a922aa1769461637869a0a2faa3f53",
-                "reference": "50953a2691a922aa1769461637869a0a2faa3f53",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
                 "shasum": ""
             },
             "require": {
@@ -460,9 +460,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
             },
-            "time": "2021-09-20T12:20:58+00:00"
+            "time": "2021-11-30T19:35:32+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -630,16 +630,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -650,7 +650,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -680,22 +681,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
-                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
                 "shasum": ""
             },
             "require": {
@@ -730,22 +731,22 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.1"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
             },
-            "time": "2021-10-02T14:08:47+00:00"
+            "time": "2022-01-04T19:58:01+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
                 "shasum": ""
             },
             "require": {
@@ -797,29 +798,29 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
-            "time": "2021-09-10T09:02:12+00:00"
+            "time": "2021-12-08T12:19:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.7",
+            "version": "9.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "d4c798ed8d51506800b441f7a13ecb0f76f12218"
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d4c798ed8d51506800b441f7a13ecb0f76f12218",
-                "reference": "d4c798ed8d51506800b441f7a13ecb0f76f12218",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.12.0",
+                "nikic/php-parser": "^4.13.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -868,7 +869,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.7"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
             },
             "funding": [
                 {
@@ -876,20 +877,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-09-17T05:39:03+00:00"
+            "time": "2021-12-05T09:12:13+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
@@ -928,7 +929,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -936,7 +937,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:57:25+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -1121,16 +1122,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.10",
+            "version": "9.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a"
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
-                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/597cb647654ede35e43b137926dfdfef0fb11743",
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743",
                 "shasum": ""
             },
             "require": {
@@ -1208,11 +1209,11 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.10"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.13"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/donate.html",
+                    "url": "https://phpunit.de/sponsors.html",
                     "type": "custom"
                 },
                 {
@@ -1220,24 +1221,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-09-25T07:38:51+00:00"
+            "time": "2022-01-24T07:33:35+00:00"
         },
         {
             "name": "psr/container",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "2ae37329ee82f91efadc282cc2d527fd6065a5ef"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/2ae37329ee82f91efadc282cc2d527fd6065a5ef",
-                "reference": "2ae37329ee82f91efadc282cc2d527fd6065a5ef",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "extra": {
@@ -1271,9 +1272,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.1"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-03-24T13:40:57+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -1970,16 +1971,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
                 "shasum": ""
             },
             "require": {
@@ -2028,14 +2029,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
             },
             "funding": [
                 {
@@ -2043,7 +2044,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:24:23+00:00"
+            "time": "2021-11-11T14:18:36+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -2843,20 +2844,23 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.23.0",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -2902,7 +2906,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -2918,24 +2922,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-10-20T20:35:02+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.23.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
-                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -2982,7 +2989,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -2998,20 +3005,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T12:26:48+00:00"
+            "time": "2021-11-30T18:21:41+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.23.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
+                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/57b712b08eddb97c762a8caa32c84e037892d2e9",
+                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9",
                 "shasum": ""
             },
             "require": {
@@ -3065,7 +3072,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -3081,7 +3088,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-28T13:41:28+00:00"
+            "time": "2021-09-13T13:58:33+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3135,16 +3142,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.3.3",
+            "version": "v3.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a27fa056df8a6384316288ca8b0fa3a35fdeb569"
+                "reference": "8f168c6ffa3ce76d1786b3cd52275424a3fc675b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a27fa056df8a6384316288ca8b0fa3a35fdeb569",
-                "reference": "a27fa056df8a6384316288ca8b0fa3a35fdeb569",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/8f168c6ffa3ce76d1786b3cd52275424a3fc675b",
+                "reference": "8f168c6ffa3ce76d1786b3cd52275424a3fc675b",
                 "shasum": ""
             },
             "require": {
@@ -3195,7 +3202,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.3.3"
+                "source": "https://github.com/twigphp/Twig/tree/v3.3.7"
             },
             "funding": [
                 {
@@ -3207,7 +3214,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-17T08:44:23+00:00"
+            "time": "2022-01-03T21:15:37+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -3274,7 +3281,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"

--- a/src/Zeuxisoo/Whoops/Slim/WhoopsGuard.php
+++ b/src/Zeuxisoo/Whoops/Slim/WhoopsGuard.php
@@ -12,9 +12,9 @@ use Whoops\Handler\JsonResponseHandler;
 
 class WhoopsGuard {
 
-    protected $settings = [];
-    protected $request  = null;
-    protected $handlers = [];
+    protected array $settings = [];
+    protected ?ServerRequestInterface $request  = null;
+    protected array $handlers = [];
 
     /**
      * Instance the whoops guard object

--- a/src/Zeuxisoo/Whoops/Slim/WhoopsGuard.php
+++ b/src/Zeuxisoo/Whoops/Slim/WhoopsGuard.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Zeuxisoo\Whoops\Slim;
@@ -10,10 +11,12 @@ use Whoops\Util\Misc;
 use Whoops\Handler\PrettyPageHandler;
 use Whoops\Handler\JsonResponseHandler;
 
-class WhoopsGuard {
-
+class WhoopsGuard
+{
     protected array $settings = [];
-    protected ?ServerRequestInterface $request  = null;
+
+    protected ?ServerRequestInterface $request = null;
+
     protected array $handlers = [];
 
     /**
@@ -21,7 +24,8 @@ class WhoopsGuard {
      *
      * @param array $settings
      */
-    public function __construct(array $settings = []) {
+    public function __construct(array $settings = [])
+    {
         $this->settings = array_merge([
             'enable' => true,
             'editor' => '',
@@ -35,7 +39,8 @@ class WhoopsGuard {
      * @param ServerRequestInterface $request
      * @return void
      */
-    public function setRequest(ServerRequestInterface $request): void {
+    public function setRequest(ServerRequestInterface $request): void
+    {
         $this->request = $request;
     }
 
@@ -45,7 +50,8 @@ class WhoopsGuard {
      * @param array $handlers
      * @return void
      */
-    public function setHandlers(array $handlers): void {
+    public function setHandlers(array $handlers): void
+    {
         $this->handlers = $handlers;
     }
 
@@ -54,7 +60,8 @@ class WhoopsGuard {
      *
      * @return WhoopsRun|null
      */
-    public function install(): ?WhoopsRun {
+    public function install(): ?WhoopsRun
+    {
         if ($this->settings['enable'] === false) {
             return null;
         }
@@ -93,11 +100,11 @@ class WhoopsGuard {
         ]);
 
         // Set Whoops to default exception handler
-        $whoops = new \Whoops\Run;
+        $whoops = new WhoopsRun();
         $whoops->pushHandler($prettyPageHandler);
 
         // Enable JsonResponseHandler when request is AJAX
-        if (Misc::isAjaxRequest() === true){
+        if (Misc::isAjaxRequest() === true) {
             $whoops->pushHandler(new JsonResponseHandler());
         }
 
@@ -112,5 +119,4 @@ class WhoopsGuard {
 
         return $whoops;
     }
-
 }

--- a/src/Zeuxisoo/Whoops/Slim/WhoopsMiddleware.php
+++ b/src/Zeuxisoo/Whoops/Slim/WhoopsMiddleware.php
@@ -10,8 +10,8 @@ use Psr\Http\Message\ResponseInterface;
 
 class WhoopsMiddleware implements MiddlewareInterface {
 
-    protected $settings = [];
-    protected $handlers = [];
+    protected array $settings = [];
+    protected array $handlers = [];
 
     /**
      * Instance the whoops middleware object

--- a/src/Zeuxisoo/Whoops/Slim/WhoopsMiddleware.php
+++ b/src/Zeuxisoo/Whoops/Slim/WhoopsMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Zeuxisoo\Whoops\Slim;
@@ -8,9 +9,10 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class WhoopsMiddleware implements MiddlewareInterface {
-
+class WhoopsMiddleware implements MiddlewareInterface
+{
     protected array $settings = [];
+
     protected array $handlers = [];
 
     /**
@@ -19,7 +21,8 @@ class WhoopsMiddleware implements MiddlewareInterface {
      * @param array $settings
      * @param array $handlers
      */
-    public function __construct(array $settings = [], array $handlers = []) {
+    public function __construct(array $settings = [], array $handlers = [])
+    {
         $this->settings = $settings;
         $this->handlers = $handlers;
     }
@@ -31,7 +34,8 @@ class WhoopsMiddleware implements MiddlewareInterface {
      * @param RequestHandlerInterface $handler
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface {
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
         $whoopsGuard = new WhoopsGuard($this->settings);
         $whoopsGuard->setRequest($request);
         $whoopsGuard->setHandlers($this->handlers);
@@ -39,5 +43,4 @@ class WhoopsMiddleware implements MiddlewareInterface {
 
         return $handler->handle($request);
     }
-
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Zeuxisoo\Whoops\Slim\Tests;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
-abstract class TestCase extends PhpUnitTestCase {
-
+abstract class TestCase extends PhpUnitTestCase
+{
 }

--- a/tests/WhoopsGuardTest.php
+++ b/tests/WhoopsGuardTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Zeuxisoo\Whoops\Slim\Tests;
@@ -7,10 +8,11 @@ use Slim\Psr7\Factory\ServerRequestFactory;
 use Whoops\Run as WhoopsRun;
 use Zeuxisoo\Whoops\Slim\WhoopsGuard;
 
-class WhoopsGuardTest extends TestCase {
-
-    public function testShouldReturnWhoops() {
-        $request = (new ServerRequestFactory)->createServerRequest("GET", "http://example.com/");
+class WhoopsGuardTest extends TestCase
+{
+    public function testShouldReturnWhoops()
+    {
+        $request = (new ServerRequestFactory())->createServerRequest('GET', 'http://example.com/');
 
         $guard = new WhoopsGuard();
         $guard->setRequest($request);
@@ -20,8 +22,9 @@ class WhoopsGuardTest extends TestCase {
         $this->assertInstanceOf(WhoopsRun::class, $whoops);
     }
 
-    public function testShouldNotReturnWhoopsWhenDisabled() {
-        $request = (new ServerRequestFactory)->createServerRequest("GET", "http://example.com/");
+    public function testShouldNotReturnWhoopsWhenDisabled()
+    {
+        $request = (new ServerRequestFactory())->createServerRequest('GET', 'http://example.com/');
 
         $guard = new WhoopsGuard([
             'enable' => false,
@@ -33,8 +36,9 @@ class WhoopsGuardTest extends TestCase {
         $this->assertNull($whoops);
     }
 
-    public function testSetCustomHandlers() {
-        $request = (new ServerRequestFactory)->createServerRequest("GET", "http://example.com/");
+    public function testSetCustomHandlers()
+    {
+        $request = (new ServerRequestFactory())->createServerRequest("GET", "http://example.com/");
 
         $guard = new WhoopsGuard();
         $guard->setRequest($request);
@@ -56,8 +60,9 @@ class WhoopsGuardTest extends TestCase {
         $this->assertEquals(2, count($whoops->getHandlers()));
     }
 
-    public function testSetEditor() {
-        $request = (new ServerRequestFactory)->createServerRequest("GET", "http://example.com/");
+    public function testSetEditor()
+    {
+        $request = (new ServerRequestFactory())->createServerRequest('GET', 'http://example.com/');
 
         $guard = new WhoopsGuard([ 'editor' => 'sublime', ]);
         $guard->setRequest($request);
@@ -72,8 +77,9 @@ class WhoopsGuardTest extends TestCase {
         );
     }
 
-    public function testPageTitle() {
-        $request = (new ServerRequestFactory)->createServerRequest("GET", "http://example.com/");
+    public function testPageTitle()
+    {
+        $request = (new ServerRequestFactory())->createServerRequest('GET', 'http://example.com/');
 
         $guard = new WhoopsGuard([ 'title' => 'Hello World', ]);
         $guard->setRequest($request);

--- a/tests/WhoopsMiddlewareTest.php
+++ b/tests/WhoopsMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Zeuxisoo\Whoops\Slim\Tests;
@@ -9,14 +10,15 @@ use Slim\Psr7\Factory\ResponseFactory;
 use Equip\Dispatch\MiddlewareCollection;
 use Zeuxisoo\Whoops\Slim\WhoopsMiddleware;
 
-class WhoopsMiddlewareTest extends TestCase {
-
-    public function testInstall() {
-        $request = (new ServerRequestFactory)->createServerRequest("GET", "https://example.com/");
+class WhoopsMiddlewareTest extends TestCase
+{
+    public function testInstall()
+    {
+        $request = (new ServerRequestFactory())->createServerRequest('GET', 'https://example.com/');
 
         $default = function(RequestInterface $request) {
             $response = (new ResponseFactory)->createResponse();
-            $response->getBody()->write("Success");
+            $response->getBody()->write('Success');
 
             return $response;
         };
@@ -28,7 +30,6 @@ class WhoopsMiddlewareTest extends TestCase {
         $response = $collection->dispatch($request, $default);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals("Success", $response->getBody());
+        $this->assertEquals('Success', $response->getBody());
     }
-
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
-require_once dirname(dirname(__FILE__)).'/vendor/autoload.php';
+require_once dirname(__DIR__).'/vendor/autoload.php';


### PR DESCRIPTION
This PR;
- drops support for PHP 7.3 since [it reached its end of life and is no longer supported](https://www.php.net/eol.php),
- adds support for testing on PHP 8.1,
- applies [PSR-12](https://www.php-fig.org/psr/psr-12/) rules,
- makes minor updates in README.md file.